### PR TITLE
ci: use build caches

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,6 +10,12 @@ jobs:
     container: swiftlang/swift:nightly-main-jammy
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       - run: swift --version
       - run: swift build
       - run: swift test


### PR DESCRIPTION
The job "build-linux" takes about 10 minutes. It's so slow. I hope that using caches makes it faster.