### PR TITLE
build: loosen versoin constraints

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [.macOS(.v13), .iOS(.v16)],
     dependencies: [
         .package(name: "Browser", path: ".."),
-        .package(url: "https://github.com/ordo-one/package-benchmark", "1.11.2"..<"1.12.0"),
+        .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.11.2"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
SwiftPM always uses `Package.resolved` when building an application, so I realized that `.upToNextMinor` was stricter than necessary.