### PR TITLE
ci: re-enable cache action

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,12 +12,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      # - uses: actions/cache@v3
-      #   with:
-      #     path: .build
-      #     key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-spm-
+      - uses: actions/cache@v3
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       - run: swift --version
       - run: swift build
       - run: swift test --disable-xctest


### PR DESCRIPTION
I commented out the cache action because it caused a build error, but I want to re-enable it to make running jobs faster.

I've created this pull request so that I can watch until the build error is fixed in the latest toolchain.
