### PR TITLE
build: use builtin swift-format

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,6 +21,11 @@ jobs:
       - run: swift --version
       - run: swift build
       - run: swift test --disable-xctest --enable-code-coverage --no-parallel
-      - run: swift package lint-source-code
       - run: llvm-cov export -format="lcov" .build/debug/zyphyPackageTests.swift-testing -instr-profile .build/debug/codecov/default.profdata -ignore-filename-regex=".build|Tests" > coverage_report.lcov
       - uses: k1LoW/octocov-action@v1
+  lint:
+    runs-on: ubuntu-latest
+    container: swiftlang/swift:nightly-main-jammy
+    steps:
+      - uses: actions/checkout@v4
+      - run: swift format lint -rs .

--- a/.swift-format
+++ b/.swift-format
@@ -19,7 +19,7 @@
       "XCTAssertNoThrow"
     ]
   },
-  "prioritizeKeepingFunctionOutputTogether" : false,
+  "prioritizeKeepingFunctionOutputTogether" : true,
   "respectsExistingLineBreaks" : true,
   "rules" : {
     "AllPublicDeclarationsHaveDocumentation" : false,

--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "da2d8685996c22e50d5f3ea9604fdd68d6d691c484d1a2c5ca3c692848f7de3f",
+  "originHash" : "c5522218311ed34b27fc0276b3ebe431ca32b9faa9993378585a242777c3d74f",
   "pins" : [
     {
       "identity" : "hdrhistogram-swift",
@@ -35,33 +35,6 @@
       "state" : {
         "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
         "version" : "1.2.0"
-      }
-    },
-    {
-      "identity" : "swift-cmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-cmark.git",
-      "state" : {
-        "revision" : "f218e5d7691f78b55bfa39b367763f4612486c35",
-        "version" : "0.3.0"
-      }
-    },
-    {
-      "identity" : "swift-format",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-format",
-      "state" : {
-        "revision" : "83248b4fa37919f78ffbd4650946759bcc54c2b5",
-        "version" : "509.0.0"
-      }
-    },
-    {
-      "identity" : "swift-markdown",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-markdown.git",
-      "state" : {
-        "revision" : "e4f95e2dc23097a1a9a1dfdfe3fe3ee44de77378",
-        "version" : "0.3.0"
       }
     },
     {

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -8,8 +8,6 @@ let package = Package(
     dependencies: [
         .package(name: "zyphy", path: ".."),
         .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.22.1"),
-        // dev
-        .package(url: "https://github.com/apple/swift-format", from: "509.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,42 +1,6 @@
 {
-  "originHash" : "5c2870c34d7e013f1ac16bf0f8bd1d1312b406bdbb101ec6c1b0cd80c6d0dde7",
+  "originHash" : "2b26cc864beb6497d489a0c6f5818eed1977f0b9c343bc6e58ccda893283c125",
   "pins" : [
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-cmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-cmark.git",
-      "state" : {
-        "revision" : "f218e5d7691f78b55bfa39b367763f4612486c35",
-        "version" : "0.3.0"
-      }
-    },
-    {
-      "identity" : "swift-format",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-format",
-      "state" : {
-        "revision" : "83248b4fa37919f78ffbd4650946759bcc54c2b5",
-        "version" : "509.0.0"
-      }
-    },
-    {
-      "identity" : "swift-markdown",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-markdown.git",
-      "state" : {
-        "revision" : "e4f95e2dc23097a1a9a1dfdfe3fe3ee44de77378",
-        "version" : "0.3.0"
-      }
-    },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"510.0.0"),
         .package(url: "https://github.com/apple/swift-testing", from: "0.4.2"),
-        // dev
-        .package(url: "https://github.com/apple/swift-format", from: "509.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
I have been using swift-format as a SwiftPM plugin since #14, but swift-format seems to be included in the recent main snapshot toolchain, so I decided to use that one.

This will speed up CI.