### PR TITLE
build(benchmark): bump package-benchmark to 1.22.2

### DIFF
--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/package-benchmark",
       "state" : {
-        "revision" : "ddf6c1ae01e139120bcdb917ece52819ee69d47a",
-        "version" : "1.22.1"
+        "revision" : "1c0c52280bfb49b53958f446f23418b7e449abf2",
+        "version" : "1.22.2"
       }
     },
     {

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [.macOS(.v13), .iOS(.v16)],
     dependencies: [
         .package(name: "zyphy", path: ".."),
-        .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.22.1"),
+        .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.22.2"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
https://github.com/ordo-one/package-benchmark/releases/tag/1.22.2