### PR TITLE
build: bump swift-tools-version to 6.0

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.11
+// swift-tools-version: 6.0
 
 import PackageDescription
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c462a755756488d11ed5f9e2772e1badb33a1a0c541f37e442fba8e58f87a0e0",
+  "originHash" : "05061584b47596e207d8b309781cf91a9cfdc00a0a2a326e79c931eb6295edd2",
   "pins" : [
     {
       "identity" : "swift-syntax",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-testing",
       "state" : {
-        "revision" : "0c1f164b2d4272a3afce622a9e3eb0163d931fb4",
-        "version" : "0.5.0"
+        "branch" : "main",
+        "revision" : "9de726b57e25482eedb445a13189fbade0e64a89"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.11
+// swift-tools-version: 6.0
 
 import CompilerPluginSupport
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"510.0.0"),
-        .package(url: "https://github.com/apple/swift-testing", from: "0.5.0"),
+        .package(url: "https://github.com/apple/swift-testing", branch: "main"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Swift 5.11 is now Swift 6.0. When the development snapshot CI is passed next time, we should be able to change `swift-tools-version` to `6.0`.